### PR TITLE
Supported GHC 9.0.1.

### DIFF
--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        ghc-ver: [8.10.4, 8.10.3, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
+        ghc-ver: [9.0.1, 8.10.4, 8.10.3, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
     env:
       ARGS: "--stack-yaml stack-${{ matrix.ghc-ver }}.yaml --no-terminal --system-ghc"
 

--- a/stack-9.0.1.yaml
+++ b/stack-9.0.1.yaml
@@ -1,0 +1,49 @@
+resolver: ghc-9.0.1
+compiler: ghc-9.0.1
+compiler-check: match-exact
+
+extra-deps:
+  - aeson-1.5.5.1
+  - assoc-1.0.2
+  - attoparsec-0.13.2.4
+  - base-compat-0.11.2
+  - base-compat-batteries-0.11.2
+  - base-orphans-0.8.4
+  - bifunctors-5.5.10
+  - clock-0.8.2
+  - comonad-5.0.8
+  - conduit-1.3.4
+  - data-fix-0.3.1
+  - distributive-0.6.2.1
+  - dlist-1.0
+  - extra-1.7.9
+  - indexed-traversable-0.1.1
+  - integer-logarithms-1.0.3.1
+  - filepattern-0.1.2
+  - hashable-1.3.1.0
+  - libyaml-0.1.2
+  - mono-traversable-1.0.15.1
+  - primitive-0.7.1.0
+  - random-1.2.0
+  - resourcet-1.2.4.2
+  - scientific-0.3.6.2
+  - split-0.2.3.4
+  - splitmix-0.1.0.3
+  - strict-0.4.0.1
+  - tagged-0.8.6.1
+  - th-abstraction-0.4.2.0
+  - these-1.1.1.1
+  - time-compat-1.9.5
+  - transformers-compat-0.6.6
+  - unliftio-core-0.2.0.1
+  - unordered-containers-0.2.13.0
+  - uuid-types-1.0.4
+  - vector-0.12.2.0
+  - vector-algorithms-0.8.0.4
+  - yaml-0.11.5.0
+
+allow-newer: true
+
+flags:
+  transformers-compat:
+    five-three: true


### PR DESCRIPTION
I added `allow-newer: true` to the `stack-9.0.1.yaml` file because
https://github.com/byorgey/split/issues/9.