### PR TITLE
[ fix-whitespace #5228 ] Tweak .cabal file for release on hackage

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2021, Nils Anders Danielsson, Ulf Norell, Andrés Sicard-Ramírez, Andreas Abel, Philipp Hausmann, Jesper Cockx, Vlad Semenov, and Liang-Ting Chen
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Andreas Abel and Beatrice Vergani nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/fix-whitespace.cabal
+++ b/fix-whitespace.cabal
@@ -1,20 +1,22 @@
 name:            fix-whitespace
 version:         0.0.5
-cabal-version:   >= 1.8
+cabal-version:   >= 1.10
 build-type:      Simple
 description:     Removes trailing whitespace, lines containing only whitespace and ensure that every file ends in a newline character.
 maintainer:      Liang-Ting Chen <liang.ting.chen.tw@gmail.com>
 homepage:        https://github.com/agda/fix-whitespace
 bug-reports:     https://github.com/agda/fix-whitespace/issues
 author:          fix-whitespace was originally rewritten by Nils Anders Danielsson with contributions from Ulf Norell, Andrés Sicard-Ramírez, Andreas Abel, Philipp Hausmann, Jesper Cockx, Vlad Semenov, and Liang-Ting Chen.
+license:         BSD3
+license-file:    LICENSE
 Category:        Text
 Synopsis:        Fixes whitespace issues.
 tested-with:     GHC == 8.0.2
                  GHC == 8.2.2
                  GHC == 8.4.4
                  GHC == 8.6.5
-                 GHC == 8.8.3
-                 GHC == 8.10.1
+                 GHC == 8.8.4
+                 GHC == 8.10.4
 
 source-repository head
   type: git
@@ -24,14 +26,17 @@ executable fix-whitespace
   hs-source-dirs:   .
   main-is:          FixWhitespace.hs
   other-modules:    ParseConfig
-  ghc-options:      -O2
+  -- Andreas, 2021-02-21: do we need -O2?
+  -- If yes, add justification.
+  -- ghc-options:      -O2
+  default-language: Haskell2010
 
-  build-depends:  base >= 4.9.0.0 && < 4.15
-                , directory >= 1.2.6.2 && < 1.4
-                , filepath >= 1.4.1.0 && < 1.5
-                , extra >= 1.7.1 && < 1.7.3
-                , filepattern >= 0.1.2 && < 0.1.3
-                , yaml >= 0.8.4 && < 0.12
+  build-depends:  base        >= 4.9.0.0 && < 4.16
+                , directory   >= 1.2.6.2 && < 1.4
+                , filepath    >= 1.4.1.0 && < 1.5
+                , extra       >= 1.7.1   && < 1.8
+                , filepattern >= 0.1.2   && < 0.1.3
+                , yaml        >= 0.8.4   && < 0.12
 
   -- ASR (2018-10-16). Required for supporting GHC 8.4.1, 8.4.2 and
   -- 8.4.3. See Issue #3277.


### PR DESCRIPTION
[ fix-whitespace #5228 ] Tweak .cabal file for release on hackage

TODO:
- [ ] confirm BSD3 license
- [ ] decide `-O2`

UPDATE: I seem to have forgotten about #4, where I advocated the Unlicense. 😊 