### PR TITLE
Use Agda's license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# fix-whitespace
+
+Version history.
+
+## 0.0.5 released 2021-03-11
+
+- initial release
+- tested with GHC 8.0.2 - 9.0.1

--- a/FixWhitespace.hs
+++ b/FixWhitespace.hs
@@ -1,8 +1,7 @@
 -- Liang-Ting Chen 2019-10-13:
--- this program is partially re-written such that
--- the configuration part is controllfed by an external
--- configuration file `fix-whitespace.yaml"
--- in the base directory instead.
+-- this program is partially re-written so that the configuration part is
+-- controlled by a configuration file `fix-whitespace.yaml" in the base
+-- directory instead.
 
 import Control.Monad
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,70 @@
+Copyright (c) 2005-2020 remains with the authors.
+Agda 2 was originally written by Ulf Norell,
+partially based on code from Agda 1 by Catarina Coquand and Makoto Takeyama,
+and from Agdalight by Ulf Norell and Andreas Abel.
+
+Agda 2 is currently actively developed mainly by Andreas Abel,
+Guillaume Allais, Jesper Cockx, Nils Anders Danielsson, Philipp
+Hausmann, Fredrik Nordvall Forsberg, Ulf Norell, Víctor López Juan,
+Andrés Sicard-Ramírez, and Andrea Vezzosi.
+
+Further, Agda 2 has received contributions by, amongst others, Stevan
+Andjelkovic, Marcin Benke, Jean-Philippe Bernardy, Guillaume Brunerie,
+James Chapman, Dominique Devriese, Péter Diviánszky, Olle Fredriksson,
+Adam Gundry, Daniel Gustafsson, Kuen-Bang Hou (favonia), Patrik
+Jansson, Alan Jeffrey, Wolfram Kahl, Wen Kokke, Fredrik Lindblad,
+Francesco Mazzoli, Stefan Monnier, Darin Morrison, Guilhem Moulin,
+Nicolas Pouillard, Nobuo Yamashita, Christian Sattler, Makoto
+Takeyama and Tesla Ice Zhang.  The full list of contributors is
+available at https://github.com/agda/agda/graphs/contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+The file src/full/Agda/Utils/Maybe/Strict.hs (and the following
+license text?) uses the following license:
+
+Copyright (c) Roman Leshchinskiy 2006-2007
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the author nor the names of his contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,9 @@
-Copyright (c) 2005-2020 remains with the authors.
-Agda 2 was originally written by Ulf Norell,
-partially based on code from Agda 1 by Catarina Coquand and Makoto Takeyama,
-and from Agdalight by Ulf Norell and Andreas Abel.
+Copyright (c) 2005-2021 remains with the authors.
 
-Agda 2 is currently actively developed mainly by Andreas Abel,
-Guillaume Allais, Jesper Cockx, Nils Anders Danielsson, Philipp
-Hausmann, Fredrik Nordvall Forsberg, Ulf Norell, Víctor López Juan,
-Andrés Sicard-Ramírez, and Andrea Vezzosi.
-
-Further, Agda 2 has received contributions by, amongst others, Stevan
-Andjelkovic, Marcin Benke, Jean-Philippe Bernardy, Guillaume Brunerie,
-James Chapman, Dominique Devriese, Péter Diviánszky, Olle Fredriksson,
-Adam Gundry, Daniel Gustafsson, Kuen-Bang Hou (favonia), Patrik
-Jansson, Alan Jeffrey, Wolfram Kahl, Wen Kokke, Fredrik Lindblad,
-Francesco Mazzoli, Stefan Monnier, Darin Morrison, Guilhem Moulin,
-Nicolas Pouillard, Nobuo Yamashita, Christian Sattler, Makoto
-Takeyama and Tesla Ice Zhang.  The full list of contributors is
-available at https://github.com/agda/agda/graphs/contributors
+fix-whitespace was originally written by Nils Anders Danielsson as
+part of Agda 2 with contributions from Ulf Norell,
+Andrés Sicard-Ramírez, Andreas Abel, Philipp Hausmann, Jesper Cockx,
+Vlad Semenov, and Liang-Ting Chen.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -36,35 +23,3 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
---------------------------------------------------------------------------------
-
-The file src/full/Agda/Utils/Maybe/Strict.hs (and the following
-license text?) uses the following license:
-
-Copyright (c) Roman Leshchinskiy 2006-2007
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
-3. Neither the name of the author nor the names of his contributors
-   may be used to endorse or promote products derived from this software
-   without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE CONTRIBUTORS ``AS IS'' AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,32 +1,44 @@
-fix-whitespace: Fixes whitespace issues. [![Build Status](https://travis-ci.org/agda/fix-whitespace.svg?branch=master)](https://travis-ci.org/agda/fix-whitespace)
----------------------------------------------
+fix-whitespace: Fixes whitespace issues
+=======================================
+
+[![Hackage version](https://img.shields.io/hackage/v/fix-whitespace.svg?label=Hackage)](http://hackage.haskell.org/package/fix-whitespace)
+[![Hackage CI](https://matrix.hackage.haskell.org/api/v2/packages/fix-whitespace/badge)](https://matrix.hackage.haskell.org/package/fix-whitespace)
+[![fix-whitespace on Stackage Nightly](https://stackage.org/package/fix-whitespace/badge/nightly)](https://stackage.org/nightly/package/fix-whitespace)
+[![Stackage LTS version](https://www.stackage.org/package/fix-whitespace/badge/lts?label=Stackage)](https://www.stackage.org/package/fix-whitespace)
+[![Build status](https://github.com/agda/fix-whitespace/workflows/Build%20by%20Stack/badge.svg)](https://github.com/agda/fix-whitespace/actions)
+
+
+This tool can keep your project and repository clean of trailing
+whitespace and missing terminal newline.
 
 Usage: `fix-whitespace [-h|--help] [-v|--verbose] [--check] [--config CONFIG] [FILES]`
 
-The program does the following
+The program does the following to files specified in `FILES` or in the
+configuration file `fix-whitespace.yaml` under the current directory
+(and its subdirectories):
 
-* Removes trailing whitespace.
-* Removes trailing lines containing nothing but whitespace.
-* Ensures that the file ends in a newline character.
-
-for files specified in `[FILES]` or
-
-        fix-whitespace.yaml
-
-under the current directory.
-
-Background: Agda was reported to fail to compile on Windows
-because a file did not end with a newline character (Agda
-uses `-Werror`).
+  * Remove trailing whitespace.
+  * Remove trailing lines containing nothing but whitespace.
+  * Ensure that the file ends in a newline character.
 
 Available options:
 
-*  `-h  --help`           Show this help information.
+*  `-h  --help`
 
-*  `-v  --verbose`        Show files as they are being checked.
+   Show this help information.
 
-*  `--config=CONFIG`  Override the project configuration `fix-whitespace.yaml`.
+*  `-v  --verbose`
 
-*  `--check`          With `--check` the program does not change any files,
-                       it just checks if any files would have been changed.
-                       In this case it returns with a non-zero exit code.
+   Show files as they are being checked.
+
+*  `--config=CONFIG`
+
+   Override the project configuration `fix-whitespace.yaml`.
+
+*  `--check`
+
+   With `--check` the program does not change any files,
+   it just checks if any files would have been changed.
+   In this case it returns with a non-zero exit code.
+
+For an example configuration file see [the one of Agda](https://github.com/agda/agda/blob/f9a181685397517b5d14943ca88a1c0acacc2075/fix-whitespace.yaml).

--- a/fix-whitespace.cabal
+++ b/fix-whitespace.cabal
@@ -20,6 +20,10 @@ tested-with:     GHC == 8.0.2
                  GHC == 8.10.4
                  GHC == 9.0.1
 
+extra-source-files:
+  CHANGELOG.md
+  README.md
+
 source-repository head
   type: git
   location: https://github.com/agda/fix-whitespace.git

--- a/fix-whitespace.cabal
+++ b/fix-whitespace.cabal
@@ -5,7 +5,7 @@ build-type:      Simple
 description:     Removes trailing whitespace, lines containing only whitespace and ensure that every file ends in a newline character.
 license:         OtherLicense
 license-file:    LICENSE
-author:          fix-whitespace was originally rewritten by Nils Anders Danielsson as part of Agda 2 with contributions from Ulf Norell, Andrés Sicard-Ramírez, Andreas Abel, Philipp Hausmann, Jesper Cockx, Vlad Semenov, and Liang-Ting Chen.
+author:          fix-whitespace was originally written by Nils Anders Danielsson as part of Agda 2 with contributions from Ulf Norell, Andrés Sicard-Ramírez, Andreas Abel, Philipp Hausmann, Jesper Cockx, Vlad Semenov, and Liang-Ting Chen.
 homepage:        https://github.com/agda/fix-whitespace
 bug-reports:     https://github.com/agda/fix-whitespace/issues
 maintainer:      Liang-Ting Chen <liang.ting.chen.tw@gmail.com>
@@ -29,16 +29,17 @@ executable fix-whitespace
   main-is:          FixWhitespace.hs
   other-modules:    ParseConfig
 
-  build-depends:  base >= 4.9.0.0 && < 4.16
-                , directory >= 1.2.6.2 && < 1.4
-                , filepath >= 1.4.1.0 && < 1.5
-                , filepattern >= 0.1.2 && < 0.1.3
-                , extra >= 1.1 && < 2.0
-                , yaml >= 0.8.4 && < 0.12
+  build-depends:  base         >= 4.9.0.0  &&  < 4.16
+                , directory    >= 1.2.6.2  &&  < 1.4
+                , extra        >= 1.1      &&  < 2.0
+                , filepath     >= 1.4.1.0  &&  < 1.5
+                , filepattern  >= 0.1.2    &&  < 0.1.3
+                , text         >= 1.2.3.0  &&  < 1.3
+                , yaml         >= 0.8.4    &&  < 0.12
 
-  -- ASR (2018-10-16). Required for supporting GHC 8.4.1, 8.4.2 and
+  -- ASR (2018-10-16).
+  -- text-1.2.3.0 required for supporting GHC 8.4.1, 8.4.2 and
   -- 8.4.3. See Issue #3277.
-  if impl(ghc >= 8.4.1) && impl(ghc <= 8.4.3)
-    build-depends: text >= 1.2.3.0 && < 1.3
-  else
-    build-depends: text >= 1.2.3.1 && < 1.3
+  -- The other GHC versions can restrict to >= 1.2.3.1.
+  if impl(ghc < 8.4.1) || impl(ghc > 8.4.3)
+    build-depends: text >= 1.2.3.1

--- a/fix-whitespace.cabal
+++ b/fix-whitespace.cabal
@@ -3,10 +3,12 @@ version:         0.0.5
 cabal-version:   >= 1.8
 build-type:      Simple
 description:     Removes trailing whitespace, lines containing only whitespace and ensure that every file ends in a newline character.
-maintainer:      Liang-Ting Chen <liang.ting.chen.tw@gmail.com>
+license:         OtherLicense
+license-file:    LICENSE
+author:          fix-whitespace was originally rewritten by Nils Anders Danielsson as part of Agda 2 with contributions from Ulf Norell, Andrés Sicard-Ramírez, Andreas Abel, Philipp Hausmann, Jesper Cockx, Vlad Semenov, and Liang-Ting Chen.
 homepage:        https://github.com/agda/fix-whitespace
 bug-reports:     https://github.com/agda/fix-whitespace/issues
-author:          fix-whitespace was originally rewritten by Nils Anders Danielsson with contributions from Ulf Norell, Andrés Sicard-Ramírez, Andreas Abel, Philipp Hausmann, Jesper Cockx, Vlad Semenov, and Liang-Ting Chen.
+maintainer:      Liang-Ting Chen <liang.ting.chen.tw@gmail.com>
 Category:        Text
 Synopsis:        Fixes whitespace issues.
 tested-with:     GHC == 8.0.2
@@ -26,7 +28,6 @@ executable fix-whitespace
   hs-source-dirs:   .
   main-is:          FixWhitespace.hs
   other-modules:    ParseConfig
-  ghc-options:      -O2
 
   build-depends:  base >= 4.9.0.0 && < 4.16
                 , directory >= 1.2.6.2 && < 1.4

--- a/fix-whitespace.cabal
+++ b/fix-whitespace.cabal
@@ -1,6 +1,6 @@
 name:            fix-whitespace
 version:         0.0.5
-cabal-version:   >= 1.8
+cabal-version:   >= 1.10
 build-type:      Simple
 description:     Removes trailing whitespace, lines containing only whitespace and ensure that every file ends in a newline character.
 license:         OtherLicense
@@ -28,6 +28,7 @@ executable fix-whitespace
   hs-source-dirs:   .
   main-is:          FixWhitespace.hs
   other-modules:    ParseConfig
+  default-language: Haskell2010
 
   build-depends:  base         >= 4.9.0.0  &&  < 4.16
                 , directory    >= 1.2.6.2  &&  < 1.4


### PR DESCRIPTION
https://github.com/agda/fix-whitespace/pull/4#issuecomment-642890650 binds us to the original Agda license, which is also fine, I think.

I salvaged some of @L-TChen 's commit from #4 and deleted the irrelevant parts of the Agda license.
