### PR TITLE
Release 0.0.6 to fix the version number

### DIFF
--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        ghc-ver: [9.0.1, 8.10.4, 8.10.3, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
+        ghc-ver: [9.0.1, 8.10.5, 8.10.4, 8.10.3, 8.8.4, 8.8.3, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
     env:
       ARGS: "--stack-yaml stack-${{ matrix.ghc-ver }}.yaml --no-terminal --system-ghc"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 Version history.
 
+## 0.0.6 released 2021-07-29
+
+- Fix the release version: The tag `0.0.5` on the GitHub repo was released on 14 Oct 2019 while `0.0.5` on Hackage is the commit `1394ec6`.
+- Include `-Wall` and `-Wcompact` during compilation.
+- Update `stack-x.y.z.yaml` and add `stack-8.10.5.yaml`.
+
 ## 0.0.5 released 2021-03-11
 
-- initial release
-- tested with GHC 8.0.2 - 9.0.1
+- initial release.
+- tested with GHC 8.0.2 - 9.0.1.

--- a/fix-whitespace.cabal
+++ b/fix-whitespace.cabal
@@ -15,14 +15,27 @@ tested-with:     GHC == 8.0.2
                  GHC == 8.2.2
                  GHC == 8.4.4
                  GHC == 8.6.5
+                 GHC == 8.8.3
                  GHC == 8.8.4
                  GHC == 8.10.3
                  GHC == 8.10.4
+                 GHC == 8.10.5
                  GHC == 9.0.1
 
 extra-source-files:
   CHANGELOG.md
   README.md
+  fix-whitespace.yaml
+  stack-8.0.2.yaml
+  stack-8.2.2.yaml
+  stack-8.4.4.yaml
+  stack-8.6.5.yaml
+  stack-8.8.3.yaml
+  stack-8.8.4.yaml
+  stack-8.10.3.yaml
+  stack-8.10.4.yaml
+  stack-8.10.5.yaml
+  stack-9.0.1.yaml
 
 source-repository head
   type: git

--- a/fix-whitespace.cabal
+++ b/fix-whitespace.cabal
@@ -1,5 +1,5 @@
 name:            fix-whitespace
-version:         0.0.5
+version:         0.0.6
 cabal-version:   >= 1.10
 build-type:      Simple
 description:     Removes trailing whitespace, lines containing only whitespace and ensure that every file ends in a newline character.

--- a/stack-8.10.3.yaml
+++ b/stack-8.10.3.yaml
@@ -1,3 +1,3 @@
-resolver: lts-17.0
+resolver: lts-17.2
 compiler: ghc-8.10.3
 compiler-check: match-exact

--- a/stack-8.10.5.yaml
+++ b/stack-8.10.5.yaml
@@ -1,3 +1,3 @@
 resolver: lts-18.4
-compiler: ghc-8.10.4
+compiler: ghc-8.10.5
 compiler-check: match-exact

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.26
+resolver: lts-16.31
 compiler: ghc-8.8.4
 compiler-check: match-exact
 

--- a/stack-9.0.1.yaml
+++ b/stack-9.0.1.yaml
@@ -1,46 +1,6 @@
-resolver: ghc-9.0.1
+resolver: nightly-2021-07-29
 compiler: ghc-9.0.1
 compiler-check: match-exact
-
-extra-deps:
-  - aeson-1.5.5.1
-  - assoc-1.0.2
-  - attoparsec-0.13.2.4
-  - base-compat-0.11.2
-  - base-compat-batteries-0.11.2
-  - base-orphans-0.8.4
-  - bifunctors-5.5.10
-  - clock-0.8.2
-  - comonad-5.0.8
-  - conduit-1.3.4
-  - data-fix-0.3.1
-  - distributive-0.6.2.1
-  - dlist-1.0
-  - extra-1.7.9
-  - indexed-traversable-0.1.1
-  - integer-logarithms-1.0.3.1
-  - filepattern-0.1.2
-  - hashable-1.3.1.0
-  - libyaml-0.1.2
-  - mono-traversable-1.0.15.1
-  - primitive-0.7.1.0
-  - random-1.2.0
-  - resourcet-1.2.4.2
-  - scientific-0.3.6.2
-  - split-0.2.3.4
-  - splitmix-0.1.0.3
-  - strict-0.4.0.1
-  - tagged-0.8.6.1
-  - th-abstraction-0.4.2.0
-  - these-1.1.1.1
-  - time-compat-1.9.5
-  - transformers-compat-0.6.6
-  - unliftio-core-0.2.0.1
-  - unordered-containers-0.2.13.0
-  - uuid-types-1.0.4
-  - vector-0.12.2.0
-  - vector-algorithms-0.8.0.4
-  - yaml-0.11.5.0
 
 flags:
   transformers-compat:


### PR DESCRIPTION
This PR is mainly for matching the release version on GitHub. It also includes updated `stack-x.y.z.yaml`'s and a new one for GHC 8.10.5.