### PR TITLE
CI stack: try to fix 8.4.4 by installing libnuma

### DIFF
--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -14,17 +14,29 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: haskell/actions/setup@v1
+      id: haskell-setup
       with:
         ghc-version: ${{ matrix.ghc-ver }}
         enable-stack: true
+
+    - name: Set environment variables based on Haskell setup
+      shell: bash
+      run: |
+        export STACK_VER=$(stack --numeric-version)
+        echo "STACK_VER=${STACK_VER}" >> ${GITHUB_ENV}
 
     - uses: actions/cache@v2
       name: Cache dependencies
       id: cache
       with:
-        path: "~/.stack"
+        path: ${{ steps.haskell-setup.outputs.stack-root }}
         # A unique cache is used for each stack.yaml.
-        key: ${{ runner.os }}-stack-without-ghc-${{ matrix.ghc-ver }}-${{ hashFiles(format('stack-{0}.yaml', matrix.ghc-ver)) }}
+        key: ${{ runner.os }}-stack-without-ghc-${{ env.STACK_VER }}-${{ hashFiles(format('stack-{0}.yaml', matrix.ghc-ver)) }}
+
+    - name: Install the numa library (Ubuntu, GHC 8.4.4)
+      if: ${{ runner.os == 'Linux' && matrix.ghc-ver == '8.4.4' }}
+      run: |
+        sudo apt-get install libnuma-dev -qq
 
     - name: Install dependencies
       if: ${{ !steps.cache.outputs.cache-hit }}


### PR DESCRIPTION
CI stack: try to fix GHC 8.4.4 build by installing libnuma

Copied from https://github.com/agda/agda/blob/7f58030124fa99dfbf8db376659416f3ad8384de/src/github/workflows/stack.yml#L143-L146