### PR TITLE
[ #32 ] Add `--version` flag to options

### DIFF
--- a/FixWhitespace.hs
+++ b/FixWhitespace.hs
@@ -6,6 +6,7 @@ import Control.Exception (IOException, handle)
 import Data.Char as Char
 import Data.List.Extra (nubOrd)
 import Data.Text (Text)
+import Data.Version (showVersion)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text  -- Strict IO.
 
@@ -19,6 +20,7 @@ import System.IO
 import System.Console.GetOpt
 
 import ParseConfig
+import qualified Paths_fix_whitespace as PFW (version)
 
 -- | Default configuration file.
 
@@ -38,6 +40,8 @@ data Options = Options
   -- ^ Display the location of a file being checked or not.
   , optHelp    :: Bool
   -- ^ Display the help information.
+  , optVersion :: Bool
+  -- ^ Display the program's version.
   , optMode    :: Mode
   , optConfig  :: FilePath
   -- ^ The location to the configuration file.
@@ -47,6 +51,7 @@ defaultOptions :: Options
 defaultOptions = Options
   { optVerbose = False
   , optHelp    = False
+  , optVersion = False
   , optMode    = Fix
   , optConfig  = defaultConfigFile
   }
@@ -56,6 +61,9 @@ options =
   [ Option ['h']     ["help"]
       (NoArg (\opts -> opts { optHelp = True }))
       "Show this help information."
+  , Option []        ["version"]
+      (NoArg (\opts -> opts { optVersion = True }))
+      "Show the program's version."
   , Option ['v']     ["verbose"]
       (NoArg (\opts -> opts { optVerbose = True }))
       "Show files as they are being checked."
@@ -113,6 +121,9 @@ main = do
 
   -- check if the user asks for help
   when (optHelp opts) $ putStr (usage progName) >> exitSuccess
+
+  -- check if the user asks for the program's version
+  when (optVersion opts) $ putStrLn (showVersion PFW.version) >> exitSuccess
 
   -- check if the configuration file exists
   configExist <- doesFileExist $ optConfig opts

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ fix-whitespace: Fixes whitespace issues
 This tool can keep your project and repository clean of trailing
 whitespace and missing terminal newline.
 
-Usage: `fix-whitespace [-h|--help] [-v|--verbose] [--check] [--config CONFIG] [FILES]`
+Usage: `fix-whitespace [-h|--help] [-v|--verbose] [--version] [--check] [--config CONFIG] [FILES]`
 
 The program does the following to files specified in `FILES` or in the
 configuration file `fix-whitespace.yaml` under the current directory
@@ -30,6 +30,10 @@ Available options:
 *  `-v  --verbose`
 
    Show files as they are being checked.
+
+*  `--version`
+
+   Show program's version.
 
 *  `--config=CONFIG`
 


### PR DESCRIPTION
This PR would close #32

I added a new `--version` flag that would display the program's current version, following the code sample that I found [here](https://stackoverflow.com/questions/33176905/is-there-a-way-to-get-version-of-cabal-package-in-source-code-of-the-package). I also added the new flag to the README file.

Let me know if there's anything else I could do on this PR! 