### PR TITLE
fix-whitespace 0.0.8 for GHC 9.4

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,33 +8,44 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20211030
+# version: 0.15.20220525
 #
-# REGENDATA ("0.13.20211030",["github","fix-whitespace.cabal"])
+# REGENDATA ("0.15.20220525",["github","fix-whitespace.cabal"])
 #
 name: Haskell-CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
+    timeout-minutes:
+      60
     container:
       image: buildpack-deps:bionic
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.1
+          - compiler: ghc-9.4.0.20220501
             compilerKind: ghc
-            compilerVersion: 9.2.1
+            compilerVersion: 9.4.0.20220501
+            setup-method: ghcup
+            allow-failure: true
+          - compiler: ghc-9.2.3
+            compilerKind: ghc
+            compilerVersion: 9.2.3
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.0.1
+          - compiler: ghc-9.0.2
             compilerKind: ghc
-            compilerVersion: 9.0.1
-            setup-method: hvr-ppa
+            compilerVersion: 9.0.2
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.7
             compilerKind: ghc
@@ -74,8 +85,9 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.8/x86_64-linux-ghcup-0.1.17.8 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            if $HEADHACKAGE; then "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml; fi
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
           else
@@ -83,7 +95,7 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.8/x86_64-linux-ghcup-0.1.17.8 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
           fi
@@ -116,7 +128,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -144,6 +156,21 @@ jobs:
             prefix: $CABAL_DIR
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
+          EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          EOF
+          fi
+          cat >> $CABAL_CONFIG <<EOF
+          program-default-options
+            ghc-options: $GHCJOBS +RTS -M3G -RTS
           EOF
           cat $CABAL_CONFIG
       - name: versions
@@ -192,6 +219,9 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(fix-whitespace)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -219,6 +249,9 @@ jobs:
         run: |
           cd ${PKGDIR_fix_whitespace} || false
           ${CABAL} -vnormal check
+      - name: haddock
+        run: |
+          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        ghc-ver: [9.2.1, 9.0.1, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
+        ghc-ver: [9.2.2, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
       fail-fast: false
     env:
       ARGS: "--stack-yaml stack-${{ matrix.ghc-ver }}.yaml --no-terminal --system-ghc"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 Version history.
 
+## 0.0.8 released 2022-05-29
+
+- New option `--version` displaying program version.
+- Tested with GHC 8.0.2 - 9.4.1 alpha.
+
 ## 0.0.7 released 2021-09-07
 
-- Supported GHC 8.10.7.
+- Support GHC 8.10.7.
 
 ## 0.0.6 released 2021-07-29
 
@@ -14,5 +19,5 @@ Version history.
 
 ## 0.0.5 released 2021-03-11
 
-- initial release.
-- tested with GHC 8.0.2 - 9.0.1.
+- Initial release.
+- Tested with GHC 8.0.2 - 9.0.1.

--- a/FixWhitespace.hs
+++ b/FixWhitespace.hs
@@ -1,5 +1,7 @@
 -- | Program to enforce a whitespace policy.
 
+module Main where
+
 import Control.Monad
 import Control.Exception (IOException, handle)
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@ fix-whitespace: Fixes whitespace issues
 =======================================
 
 [![Hackage version](https://img.shields.io/hackage/v/fix-whitespace.svg?label=Hackage&color=informational)](http://hackage.haskell.org/package/fix-whitespace)
-[![Hackage CI](https://matrix.hackage.haskell.org/api/v2/packages/fix-whitespace/badge)](https://matrix.hackage.haskell.org/package/fix-whitespace)
 [![fix-whitespace on Stackage Nightly](https://stackage.org/package/fix-whitespace/badge/nightly)](https://stackage.org/nightly/package/fix-whitespace)
 [![Stackage LTS version](https://www.stackage.org/package/fix-whitespace/badge/lts?label=Stackage)](https://www.stackage.org/package/fix-whitespace)
 [![Build status](https://github.com/agda/fix-whitespace/workflows/Build%20by%20Stack/badge.svg)](https://github.com/agda/fix-whitespace/actions)
-
+[![Haskell-CI](https://github.com/agda/fix-whitespace/actions/workflows/haskell-ci.yml/badge.svg)](https://github.com/agda/fix-whitespace/actions/workflows/haskell-ci.yml)
 
 This tool can keep your project and repository clean of trailing
 whitespace and missing terminal newline.

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,3 +1,1 @@
--- on Linux we can use ghcup to setup (some) of jobs
--- hvr-ppa latest are 9.0.1 and 8.10.4
-ghcup-jobs: >= 9.2 || > 8.10.4 && < 9.0
+branches: master

--- a/fix-whitespace.cabal
+++ b/fix-whitespace.cabal
@@ -1,6 +1,6 @@
 name:            fix-whitespace
 version:         0.0.8
-cabal-version:   2.0
+cabal-version:   1.24
 build-type:      Simple
 description:     Removes trailing whitespace, lines containing only whitespace and ensure that every file ends in a newline character.
 license:         OtherLicense
@@ -44,7 +44,6 @@ executable fix-whitespace
   main-is:          FixWhitespace.hs
   other-modules:    ParseConfig
                     Paths_fix_whitespace
-  autogen-modules:  Paths_fix_whitespace
   default-language: Haskell2010
   default-extensions:
     LambdaCase

--- a/fix-whitespace.cabal
+++ b/fix-whitespace.cabal
@@ -1,6 +1,6 @@
 name:            fix-whitespace
 version:         0.0.8
-cabal-version:   >= 1.10
+cabal-version:   2.0
 build-type:      Simple
 description:     Removes trailing whitespace, lines containing only whitespace and ensure that every file ends in a newline character.
 license:         OtherLicense
@@ -8,17 +8,19 @@ license-file:    LICENSE
 author:          fix-whitespace was originally written by Nils Anders Danielsson as part of Agda 2 with contributions from Ulf Norell, Andrés Sicard-Ramírez, Andreas Abel, Philipp Hausmann, Jesper Cockx, Vlad Semenov, and Liang-Ting Chen.
 homepage:        https://github.com/agda/fix-whitespace
 bug-reports:     https://github.com/agda/fix-whitespace/issues
-maintainer:      Liang-Ting Chen <liang.ting.chen.tw@gmail.com>
+maintainer:      Liang-Ting Chen <liang.ting.chen.tw@gmail.com>, Andreas Abel
 Category:        Text
 Synopsis:        Fixes whitespace issues.
-tested-with:     GHC == 8.0.2
-                 GHC == 8.2.2
-                 GHC == 8.4.4
-                 GHC == 8.6.5
-                 GHC == 8.8.4
-                 GHC == 8.10.7
-                 GHC == 9.0.1
-                 GHC == 9.2.1
+tested-with:
+  GHC == 9.4.1
+  GHC == 9.2.3
+  GHC == 9.0.2
+  GHC == 8.10.7
+  GHC == 8.8.4
+  GHC == 8.6.5
+  GHC == 8.4.4
+  GHC == 8.2.2
+  GHC == 8.0.2
 
 extra-source-files:
   CHANGELOG.md
@@ -30,7 +32,8 @@ extra-source-files:
   stack-8.6.5.yaml
   stack-8.8.4.yaml
   stack-8.10.7.yaml
-  stack-9.0.1.yaml
+  stack-9.0.2.yaml
+  stack-9.2.2.yaml
 
 source-repository head
   type: git
@@ -40,17 +43,19 @@ executable fix-whitespace
   hs-source-dirs:   .
   main-is:          FixWhitespace.hs
   other-modules:    ParseConfig
+                    Paths_fix_whitespace
+  autogen-modules:  Paths_fix_whitespace
   default-language: Haskell2010
   default-extensions:
     LambdaCase
     ScopedTypeVariables
 
-  build-depends:  base         >= 4.9.0.0  &&  < 4.17
+  build-depends:  base         >= 4.9.0.0  &&  < 5
                 , directory    >= 1.2.6.2  &&  < 1.4
                 , extra        >= 1.1      &&  < 2.0
                 , filepath     >= 1.4.1.0  &&  < 1.5
                 , filepattern  >= 0.1.2    &&  < 0.1.3
-                , text         >= 1.2.3.0  &&  < 1.3
+                , text         >= 1.2.3.0  &&  < 1.3   || == 2.0.*
                 , yaml         >= 0.8.4    &&  < 0.12
 
   -- ASR (2018-10-16).

--- a/stack-8.10.7.yaml
+++ b/stack-8.10.7.yaml
@@ -1,3 +1,3 @@
-resolver: lts-18.9
+resolver: lts-18.28
 compiler: ghc-8.10.7
 compiler-check: match-exact

--- a/stack-9.0.1.yaml
+++ b/stack-9.0.1.yaml
@@ -1,7 +1,0 @@
-resolver: nightly-2021-11-12
-compiler: ghc-9.0.1
-compiler-check: match-exact
-
-flags:
-  transformers-compat:
-    five-three: true

--- a/stack-9.0.2.yaml
+++ b/stack-9.0.2.yaml
@@ -1,0 +1,3 @@
+resolver: lts-19.8
+compiler: ghc-9.0.2
+compiler-check: match-exact

--- a/stack-9.2.2.yaml
+++ b/stack-9.2.2.yaml
@@ -1,0 +1,3 @@
+resolver: nightly-2022-05-28
+compiler: ghc-9.2.2
+compiler-check: match-exact


### PR DESCRIPTION
Bumping the bounds to allow GHC-9.4 is an opportunity to re-release.

Release candidate at: https://hackage.haskell.org/package/fix-whitespace-0.0.8/candidate