### PR TITLE
Fix #31: new option `--tab`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20220710
+# version: 0.15.20220808
 #
-# REGENDATA ("0.15.20220710",["github","fix-whitespace.cabal"])
+# REGENDATA ("0.15.20220808",["github","fix-whitespace.cabal"])
 #
 name: Haskell-CI
 on:
@@ -34,14 +34,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.4.0.20220623
+          - compiler: ghc-9.4.1
             compilerKind: ghc
-            compilerVersion: 9.4.0.20220623
+            compilerVersion: 9.4.1
             setup-method: ghcup
-            allow-failure: true
-          - compiler: ghc-9.2.3
+            allow-failure: false
+          - compiler: ghc-9.2.4
             compilerKind: ghc
-            compilerVersion: 9.2.3
+            compilerVersion: 9.2.4
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -87,7 +87,7 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.8/x86_64-linux-ghcup-0.1.17.8 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
@@ -97,7 +97,7 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.8/x86_64-linux-ghcup-0.1.17.8 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        ghc-ver: [9.2.3, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
+        ghc-ver: [9.2.4, 9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
       fail-fast: false
     env:
       ARGS: "--stack-yaml stack-${{ matrix.ghc-ver }}.yaml --no-terminal --system-ghc"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 Version history.
 
+## 0.0.9 released 2022-07-29
+
+- New option `--tab` to set tab-size or keep tabs.
+- Tested with GHC 8.0.2 - 9.2.3 and 9.4.1 alpha.
+
 ## 0.0.8 released 2022-05-29
 
 - New option `--version` displaying program version.
-- Tested with GHC 8.0.2 - 9.4.1 alpha.
+- Tested with GHC 8.0.2 - 9.2.2 and 9.4.1 alpha.
 
 ## 0.0.7 released 2021-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 Version history.
 
-## 0.0.9 released 2022-07-29
+## 0.0.9 released 2022-08-10
 
 - New option `--tab` to set tab-size or keep tabs
   [#31](https://github.com/agda/fix-whitespace/issues/31).
-- Tested with GHC 8.0.2 - 9.2.3 and 9.4.1 alpha.
+- Tested with GHC 8.0.2 - 9.4.1.
 
 ## 0.0.8 released 2022-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@ Version history.
 
 ## 0.0.9 released 2022-07-29
 
-- New option `--tab` to set tab-size or keep tabs.
+- New option `--tab` to set tab-size or keep tabs
+  [#31](https://github.com/agda/fix-whitespace/issues/31).
 - Tested with GHC 8.0.2 - 9.2.3 and 9.4.1 alpha.
 
 ## 0.0.8 released 2022-05-29
 
-- New option `--version` displaying program version.
+- New option `--version` displaying program version
+  [#33](https://github.com/agda/fix-whitespace/pull/33).
+- Skip files that are not UTF8 encoded, rather than crashing
+  [#29](https://github.com/agda/fix-whitespace/issues/29).
 - Tested with GHC 8.0.2 - 9.2.2 and 9.4.1 alpha.
 
 ## 0.0.7 released 2021-09-07

--- a/FixWhitespace.hs
+++ b/FixWhitespace.hs
@@ -17,7 +17,7 @@ import System.Environment
 import System.Exit
 -- import System.FilePath
 -- import System.FilePattern
-import System.FilePattern.Directory
+import System.FilePattern.Directory (getDirectoryFiles, getDirectoryFilesIgnore)
 import System.IO
 import System.Console.GetOpt
 

--- a/fix-whitespace.cabal
+++ b/fix-whitespace.cabal
@@ -14,7 +14,7 @@ Category:        Text
 Synopsis:        Fixes whitespace issues.
 tested-with:
   GHC == 9.4.1
-  GHC == 9.2.3
+  GHC == 9.2.4
   GHC == 9.0.2
   GHC == 8.10.7
   GHC == 8.8.4
@@ -34,7 +34,7 @@ extra-source-files:
   stack-8.8.4.yaml
   stack-8.10.7.yaml
   stack-9.0.2.yaml
-  stack-9.2.3.yaml
+  stack-9.2.4.yaml
 
 source-repository head
   type: git

--- a/fix-whitespace.cabal
+++ b/fix-whitespace.cabal
@@ -1,8 +1,9 @@
 name:            fix-whitespace
-version:         0.0.8
+version:         0.0.9
 cabal-version:   1.24
 build-type:      Simple
-description:     Removes trailing whitespace, lines containing only whitespace and ensure that every file ends in a newline character.
+description:     Removes trailing whitespace, lines containing only whitespace, expands tabs,
+                 and ensures that every file ends in a newline character.
 license:         OtherLicense
 license-file:    LICENSE
 author:          fix-whitespace was originally written by Nils Anders Danielsson as part of Agda 2 with contributions from Ulf Norell, Andrés Sicard-Ramírez, Andreas Abel, Philipp Hausmann, Jesper Cockx, Vlad Semenov, and Liang-Ting Chen.

--- a/stack-9.2.3.yaml
+++ b/stack-9.2.3.yaml
@@ -1,3 +1,0 @@
-resolver: nightly-2022-07-29
-compiler: ghc-9.2.3
-compiler-check: match-exact

--- a/stack-9.2.4.yaml
+++ b/stack-9.2.4.yaml
@@ -1,0 +1,3 @@
+resolver: nightly-2022-08-04
+compiler: ghc-9.2.4
+compiler-check: match-exact


### PR DESCRIPTION
Fix #31: new option `--tab`.

Use `--tab 0` to keep tabs.  This is useful for Makefiles and similar files that use tabs essentially.

Release candidate at: https://hackage.haskell.org/package/fix-whitespace-0.0.9/candidate