### PR TITLE
v0.0.11 fix #42: delete trailing tabs even with --tab=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Version history.
 
+## 0.0.11 Santa Clause edition released 2022-12-06
+
+- Delete trailing tabs even when `--tab=0`
+  [#42](https://github.com/agda/fix-whitespace/issues/42)
+- Tested with GHC 8.0.2 - 9.4.3.
+
 ## 0.0.10 released 2022-08-21
 
 - Symlink problem

--- a/FixWhitespace.hs
+++ b/FixWhitespace.hs
@@ -271,7 +271,7 @@ transform tabSize =
     reverse . dropWhile1 Text.null . reverse
 
   removeTrailingWhitespace =
-    Text.dropWhileEnd ((`elem` [Space,Format]) . generalCategory)
+    Text.dropWhileEnd $ \ c -> generalCategory c `elem` [Space,Format] || c == '\t'
 
   convertTabs = if tabSize <= 0 then id else
     Text.pack . reverse . fst . foldl convertOne ([], 0) . Text.unpack

--- a/stack-9.0.2.yaml
+++ b/stack-9.0.2.yaml
@@ -1,6 +1,3 @@
-resolver: lts-19.20
+resolver: lts-19.33
 compiler: ghc-9.0.2
 compiler-check: match-exact
-
-extra-deps:
-  - filepattern-0.1.3

--- a/stack-9.2.5.yaml
+++ b/stack-9.2.5.yaml
@@ -1,3 +1,3 @@
-resolver: lts-20.1
+resolver: lts-20.3
 compiler: ghc-9.2.5
 compiler-check: match-exact

--- a/stack-9.4.3.yaml
+++ b/stack-9.4.3.yaml
@@ -1,3 +1,3 @@
-resolver: nightly-2022-11-26
+resolver: nightly-2022-12-05
 compiler: ghc-9.4.3
 compiler-check: match-exact


### PR DESCRIPTION
Fix #42: delete trailing tabs even with `--tab=0`.
Also: bump stack.yaml files to latest snapshots.
CHANGELOG for v0.0.11.