### PR TITLE
Display violations detected (fix #7)

### DIFF
--- a/FixWhitespace.hs
+++ b/FixWhitespace.hs
@@ -5,7 +5,7 @@
 module Main where
 
 import Control.Monad
-import Control.Monad.Trans.Writer.CPS
+import Control.Monad.Trans.Writer.Strict
 import Control.Exception (IOException, handle)
 
 import Data.Char as Char

--- a/FixWhitespace.hs
+++ b/FixWhitespace.hs
@@ -223,7 +223,9 @@ fix mode verbose tabSize f =
       hPutStrLn stderr $
         "[ Violation " ++
         (if mode == Fix then "fixed" else "detected") ++
-        " ] " ++ f ++ ":\n" ++ (unlines $ map displayViolations vs)
+        " ] " ++ f ++
+        (if mode == Fix then "" else
+           ":\n" ++ (unlines $ map (displayViolations f) vs))
 
       when (mode == Fix) $
         withFile f WriteMode $ \h -> do
@@ -240,8 +242,8 @@ fix mode verbose tabSize f =
 --   Stores the index of the line and the line itself.
 data LineViolating = LV Int Text
 
-displayViolations :: LineViolating -> String
-displayViolations (LV i l) = "line " ++ show i ++ "] " ++
+displayViolations :: FilePath -> LineViolating -> String
+displayViolations fname (LV i l) = fname ++ ":" ++ show i ++ ": " ++
   (Text.unpack $ visibleSpaces l)
 
 -- | The transformation monad: maintains info about lines that
@@ -331,5 +333,5 @@ dropWhile1 p (x:xs)
 --   presentation purposes. Space turns into '·' and tab into '→'
 visibleSpaces :: Text -> Text
 visibleSpaces s
-  | Text.null s = "<empty line>"
-  | otherwise = Text.replace "\t" "→" . Text.replace " " "·" $ s
+  | Text.null s = "<NEWLINE>"
+  | otherwise = Text.replace "\t" "<TAB>" . Text.replace " " "·" $ s

--- a/fix-whitespace.cabal
+++ b/fix-whitespace.cabal
@@ -59,6 +59,7 @@ executable fix-whitespace
                 , filepattern  >= 0.1.3    &&  < 0.2
                     -- filepattern 0.1.3 fixes issue fix-whitespace#9
                 , text         >= 1.2.3.0  &&  < 1.3   || == 2.0.*
+                , transformers >= 0.5.6    &&  < 0.6
                 , yaml         >= 0.8.4    &&  < 0.12
 
   -- ASR (2018-10-16).

--- a/fix-whitespace.cabal
+++ b/fix-whitespace.cabal
@@ -59,7 +59,7 @@ executable fix-whitespace
                 , filepattern  >= 0.1.3    &&  < 0.2
                     -- filepattern 0.1.3 fixes issue fix-whitespace#9
                 , text         >= 1.2.3.0  &&  < 1.3   || == 2.0.*
-                , transformers >= 0.5.6    &&  < 0.6
+                , transformers >= 0.5.2.0  &&  < 0.7
                 , yaml         >= 0.8.4    &&  < 0.12
 
   -- ASR (2018-10-16).


### PR DESCRIPTION
This looks like this:
```
❯ cat test-show-violation/bug.hs 
import Data.List

main = 
	print "Hi!" -- the first character is tab;



❯ $fix-whitespace --check test-show-violation/bug.hs
[ Violation detected ] test-show-violation/bug.hs:
line 3] main·=·
line 4] →print·"Hi!"
line 6] <empty line>
line 7] <empty line>



```

So, I display line numbers and also make visible all spaces and tabs in the violating lines, so that it's easier to see what's happening, in particular, I show:

- spaces as middots
- tabs as right arrows
- trailing empty lines as `<empty line>`