### PR TITLE
Print line violations only under --verbose flag

### DIFF
--- a/test/Golden.hs
+++ b/test/Golden.hs
@@ -34,7 +34,7 @@ goldenTests = do
 
 goldenValue :: FilePath -> IO ByteString
 goldenValue file = do
-  checkFile defaultTabSize file >>= \case
+  checkFile defaultTabSize {-verbose: -}True file >>= \case
 
     CheckIOError e ->
       ioError e


### PR DESCRIPTION
Alleviates #48 but a proper performance fix would be better. Also, `--verbose` already existed, so I reused it. Maybe, it's a bad idea, 'cause it will be impossible to find anything in a string of `[ Checked ]` (this is what `--verbose` currently means: it prints this for all non-violating files). But that's what was suggested in #48… Opinions?

Otherwise, I put back the old implementation beside the new one, mostly. Some common bits are factors out.

<details>
<summary>Time measurements</summary>
<pre>

v0.0.11 release

❯ time $FW --check 20000-violations.txt 2> /dev/null

Executed in   36.48 millis


❯ time $FW --check 200000-violations.txt 2> /dev/null

Executed in  100.67 millis
________________________________________________________

master:

❯ time $FW --check 20000-violations.txt 2> /dev/null

Executed in  661.54 millis


❯ time $FW --check 200000-violations.txt 2> /dev/null

Executed in    6.13 secs
________________________________________________________

patch

❯ time $FW --check 20000-violations.txt 2> /dev/null

Executed in   35.82 millis


❯ time $FW --check 200000-violations.txt 2> /dev/null

Executed in  123.55 millis


❯ time $FW --check -v 20000-violations.txt 2> /dev/null

Executed in  718.26 millis

❯ time $FW --check -v 200000-violations.txt 2> /dev/null

Executed in    6.42 secs
</pre>
</details>