### PR TITLE
Add --consecutive option

### DIFF
--- a/FixWhitespace.hs
+++ b/FixWhitespace.hs
@@ -21,7 +21,7 @@ import           System.IO                    ( IOMode(WriteMode), hPutStr, hPut
 import           Text.Read                    ( readMaybe )
 
 import           Data.Text.FixWhitespace      ( CheckResult(CheckOK, CheckViolation, CheckIOError), checkFile, displayLineError
-                                              , TabSize, Verbose, defaultTabSize )
+                                              , TabSize, ConsecutiveEmptyLines, Verbose, defaultTabSize, defaultConsecutiveEmptyLines )
 
 import           ParseConfig                  ( Config(Config), parseConfig )
 import qualified Paths_fix_whitespace         as PFW ( version )
@@ -49,6 +49,7 @@ data Options = Options
   -- ^ The location to the configuration file.
   , optTabSize :: String
   -- ^ The number of spaces to expand a tab character to.  @"0"@ for keeping tabs.
+  , optConsEL  :: String
   }
 
 defaultOptions :: Options
@@ -59,6 +60,7 @@ defaultOptions = Options
   , optMode    = Fix
   , optConfig  = defaultConfigFile
   , optTabSize = show defaultTabSize
+  , optConsEL  = show defaultConsecutiveEmptyLines
   }
 
 options :: [OptDescr (Options -> Options)]
@@ -80,6 +82,12 @@ options =
       (unlines
         [ "Expand tab characters to TABSIZE (default: " ++ show defaultTabSize ++ ") many spaces."
         , "Keep tabs if 0 is given as TABSIZE."
+        ])
+  , Option ['n']     ["consecutive"]
+      (ReqArg (\ns opts -> opts { optConsEL = ns }) "LINES")
+      (unlines
+        [ "Maximum consecutive empty lines (default: " ++ show defaultConsecutiveEmptyLines ++ ")."
+        , "Unlimited if 0 is given as LINES."
         ])
   , Option []        ["config"]
       (ReqArg (\loc opts -> opts { optConfig = loc }) "CONFIG")
@@ -105,7 +113,7 @@ shortUsageHeader :: String -> String
 shortUsageHeader progName = unwords
   [ "Usage:"
   , progName
-  , "[-h|--help] [-v|--verbose] [--check] [--config CONFIG] [-t|--tab TABSIZE] [FILES]"
+  , "[-h|--help] [-v|--verbose] [--check] [--config CONFIG] [-t|--tab TABSIZE] [-n|--consecutive LINES] [FILES]"
   ]
 
 usageHeader :: String -> String
@@ -159,6 +167,9 @@ main = do
   tabSize <- maybe (die "Error: Illegal TABSIZE, must be an integer.") return $
     readMaybe $ optTabSize opts
 
+  consecutiveLines <- maybe (die "Error: Illegal LINES, must be an integer.") return $
+    readMaybe $ optConsEL opts
+
   base <- getCurrentDirectory
 
   files <- if not $ null nonOpts
@@ -198,13 +209,13 @@ main = do
       files1 <- getDirectoryFilesIgnore base incPatterns excPatterns
       return (nubOrd (files0 ++ files1))
 
-  changes <- mapM (fix mode verbose tabSize) files
+  changes <- mapM (fix mode verbose tabSize consecutiveLines) files
 
   when (or changes && mode == Check) exitFailure
 
-fix :: Mode -> Verbose -> TabSize -> FilePath -> IO Bool
-fix mode verbose tabSize f =
-  checkFile tabSize verbose f >>= \case
+fix :: Mode -> Verbose -> TabSize -> ConsecutiveEmptyLines -> FilePath -> IO Bool
+fix mode verbose tabSize consecutiveLines f =
+  checkFile tabSize consecutiveLines verbose f >>= \case
 
     CheckOK -> do
       when verbose $

--- a/FixWhitespace.hs
+++ b/FixWhitespace.hs
@@ -50,6 +50,7 @@ data Options = Options
   , optTabSize :: String
   -- ^ The number of spaces to expand a tab character to.  @"0"@ for keeping tabs.
   , optConsEL  :: String
+  -- ^ The number of consecutive empty lines allowed. Unlimited if 0.
   }
 
 defaultOptions :: Options

--- a/test/Golden.hs
+++ b/test/Golden.hs
@@ -34,7 +34,7 @@ goldenTests = do
 
 goldenValue :: FilePath -> IO ByteString
 goldenValue file = do
-  checkFile defaultTabSize {-verbose: -}True file >>= \case
+  checkFile defaultTabSize 1 {-verbose: -} True file >>= \case
 
     CheckIOError e ->
       ioError e

--- a/test/violations.golden
+++ b/test/violations.golden
@@ -1,3 +1,4 @@
 Violations:
 test/violations.txt:1: Trailing·space·
 test/violations.txt:3: Trailing·tab····
+test/violations.txt:5: <NEWLINE>

--- a/test/violations.txt
+++ b/test/violations.txt
@@ -2,4 +2,6 @@ Trailing space
 
 Trailing tab    
 
+
+
 Missing newline at end of file


### PR DESCRIPTION
Resolves https://github.com/agda/fix-whitespace/issues/68

Add an option to check for maximum count of consecutive empty lines. If zero, unlimited cmount is allowed. If 1, there cannot be empty lines (1 empty lines triggers an error) , if 2 there can be one empty line (2 consecutive empty lines trigger an error), and so on.

I fail with naming, having value 1 to disallow any empty lines makes sense, but it's not "maximum amount of empty lines", it's more of "fail if there is that much empty lines".