### PR TITLE
Print 10 violations in normal mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Version history.
 
+# 0.2
+
+- [BREAKING:] Flag `--verbose` now takes an optional argument
+  that determines the maximum number of whitespace violations printed per file.
+  This argument is an integer, defaulting to 10, but can be `all`
+  to not limit the number of violations.
+
 # 0.1 Rainy Summer edition released 2023-08-07
 
 - Flag `--verbose` now also displays locations of whitespace violations

--- a/fix-whitespace.cabal
+++ b/fix-whitespace.cabal
@@ -1,6 +1,6 @@
 cabal-version:   2.2
 name:            fix-whitespace
-version:         0.1
+version:         0.2
 build-type:      Simple
 
 category:        Text

--- a/src/Data/Text/FixWhitespace.hs
+++ b/src/Data/Text/FixWhitespace.hs
@@ -19,6 +19,7 @@ import           Control.Monad.Trans.Writer.Strict ( Writer, runWriter, tell )
 import           Control.Exception                 ( IOException, handle )
 
 import           Data.Char                         ( GeneralCategory(Space, Format), generalCategory )
+import           Data.Maybe                        ( isJust )
 import           Data.Text                         ( Text )
 import qualified Data.Text                         as Text
 import qualified Data.Text.IO                      as Text  {- Strict IO -}
@@ -27,7 +28,7 @@ import           System.IO                         ( IOMode(ReadMode), hSetEncod
 
 import           Data.List.Extra.Drop              ( dropWhileEnd1, dropWhile1 )
 
-type Verbose = Bool
+type Verbose = Maybe Int
 type TabSize = Int
 
 -- | Default tab size.
@@ -61,7 +62,7 @@ checkFile tabSize verbose f =
       hSetEncoding h utf8
       s <- Text.hGetContents h
       let (s', lvs)
-            | verbose   = transformWithLog tabSize s
+            | isJust verbose = transformWithLog tabSize s
             | otherwise = (transform tabSize s, [])
       return $ if s' == s then CheckOK else CheckViolation s' lvs
 

--- a/test/Golden.hs
+++ b/test/Golden.hs
@@ -34,7 +34,7 @@ goldenTests = do
 
 goldenValue :: FilePath -> IO ByteString
 goldenValue file = do
-  checkFile defaultTabSize {-verbose: -}True file >>= \case
+  checkFile defaultTabSize {-verbose: -} maxVerbosity file >>= \case
 
     CheckIOError e ->
       ioError e
@@ -45,3 +45,5 @@ goldenValue file = do
     CheckViolation _ errs ->
       return $ LazyText.encodeUtf8 $ LazyText.fromStrict $
         Text.unlines $ "Violations:" : map (displayLineError file) errs
+  where
+    maxVerbosity = Just (maxBound :: Int)


### PR DESCRIPTION
Using --verbose on a large project prints out too much output (see https://github.com/haskell/cabal/issues/10744)

Printing out all the violations if there are a lot of them is quite slow, printing out a lot to stdout is not that fast.

Therefore we reach a compromise where we print up to 10 reasons for failure and omit the rest. If you want all the failures you can use --verbose.

Fixes #48

----

What do you think @andreasabel ? The other solution I can think of was to add a flag which controlled whether violations were printed out. 